### PR TITLE
Add mirror links to the GH files for Linux and Windows

### DIFF
--- a/hiddifypanel/panel/user/templates/home/windows.html
+++ b/hiddifypanel/panel/user/templates/home/windows.html
@@ -36,7 +36,7 @@
     <a class="btn btn-primary"
         href="/{{hconfigs[ConfigEnum.proxy_path]}}/gh/hiddify/HiddifyN/releases/latest/download/HiddifyN.zip">
         <i class="fa-brands fa-windows fa-margin"></i> {{_('Windows')}}</a>
-    {% elif ua.os.family=="OS X" %}
+    {% elif ua.os.family=="Mac OS X" %}
     <a class="btn btn-secondary"
         href="/{{hconfigs[ConfigEnum.proxy_path]}}/gh/hiddify/hiddify-next/releases/latest/download/hiddify-macos-universal.zip">
         <i class="fa-brands fa-apple fa-margin"></i> {{_('macOS')}}</a>

--- a/hiddifypanel/panel/user/templates/home/windows.html
+++ b/hiddifypanel/panel/user/templates/home/windows.html
@@ -32,11 +32,19 @@
 
 {% macro HiddifyN_dl_link() -%}
 <div class="btn-group">
+    {% if ua.os.family=="Windows" %}
     <a class="btn btn-primary"
         href="/{{hconfigs[ConfigEnum.proxy_path]}}/gh/hiddify/HiddifyN/releases/latest/download/HiddifyN.zip">
         <i class="fa-brands fa-windows fa-margin"></i> {{_('Windows')}}</a>
-    
-
+    {% elif ua.os.family=="OS X" %}
+    <a class="btn btn-secondary"
+        href="/{{hconfigs[ConfigEnum.proxy_path]}}/gh/hiddify/hiddify-next/releases/latest/download/hiddify-macos-universal.zip">
+        <i class="fa-brands fa-apple fa-margin"></i> {{_('macOS')}}</a>
+    {% elif ua.os.family=="Linux" %}
+    <a class="btn btn-success"
+        href="/{{hconfigs[ConfigEnum.proxy_path]}}/gh/hiddify/HiddifyN/releases/latest/download/hiddify-linux-x64.zip">
+        <i class="fa-brands fa-linux fa-margin"></i> {{_('Linux')}}</a>
+    {% endif %}
 </div>
 {%- endmacro -%}
 


### PR DESCRIPTION
Right now, if I open the 'desktop' tab on macOS or Linux, I still only see a 'Windows' option there. This adds the option to download the macOS/Linux files via mirror.

<img width="861" alt="Screen Region 2023-11-02 at 22 00 56" src="https://github.com/hiddify/HiddifyPanel/assets/150431/11d77248-2a11-4b19-95ce-a7b201097abf">

Note that this is untested. I am not sure if `{% if..` can go inside a macro.