### PR TITLE
Update UserAdmin.py

### DIFF
--- a/hiddifypanel/panel/admin/UserAdmin.py
+++ b/hiddifypanel/panel/admin/UserAdmin.py
@@ -124,8 +124,11 @@ class UserAdmin(AdminLTEModelView):
         proxy_path = hconfig(ConfigEnum.proxy_path)
         # print("model.telegram_id",model.telegram_id)
         extra = ""
-        if hconfig(ConfigEnum.telegram_bot_token) and model.telegram_id:
-            extra = f'<button class="btn hbtn bg-h-blue btn-xs " onclick="show_send_message({model.id})" ><i class="fa-solid fa-paper-plane"></i></button> '
+        if hconfig(ConfigEnum.telegram_bot_token):
+            if model.telegram_id:
+                extra = f'<button class="btn hbtn bg-h-blue btn-xs " onclick="show_send_message({model.id})" ><i class="fa-solid fa-paper-plane"></i></button> '
+            else:
+                extra = f'<button class="btn hbtn bg-h-grey btn-xs disabled"><i class="fa-solid fa-paper-plane"></i></button> '
 
         link = ''
         if model.is_active:


### PR DESCRIPTION
Shows Telegram icons for all users in the admin panel, if Telegram is enabled.

Users which are not registered for Telegram are shown with greyed out disabled buttons, registered users with blue buttons. 
It is a visual improvement to have all users aligned in the table.

Before:
![2023-11-18_12-47-16_2023-11-18_11-34-56_Admin_Hiddify_Panel_–_Mozilla_](https://github.com/hiddify/HiddifyPanel/assets/25169478/f2e9ea70-bb26-42e8-bfd9-ad3994aa81c9)

After:
![2023-11-18_12-51-08_Admin_Hiddify_Panel_–_Mozilla_Firefox](https://github.com/hiddify/HiddifyPanel/assets/25169478/3e724fa8-5492-4a5d-8f94-4d175d87da7b)
