### PR TITLE
Fix download link for macos hiddify clash link.

### DIFF
--- a/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
+++ b/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
@@ -357,7 +357,7 @@ class AppAPI(MethodView):
                         ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/hiddify-clash-desktop_{version}_amd64.AppImage'
                         dto.install.append(self.__get_app_install_dto(AppInstallType.appimage, ins_url))
                     case Platform.mac:
-                        ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}x64.dmg'
+                        ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64.dmg'
                         dto.install.append(self.__get_app_install_dto(AppInstallType.dmg, ins_url))
         else:
             match platform:


### PR DESCRIPTION
Missing `_`

Fixes hiddify/Hiddify-Manager#3820