### PR TITLE
Update base_singbox_config.json.j2

### DIFF
--- a/hiddifypanel/panel/user/templates/base_singbox_config.json.j2
+++ b/hiddifypanel/panel/user/templates/base_singbox_config.json.j2
@@ -170,6 +170,7 @@
                 "domain": [
                     "github.com",
                     "githubusercontent.com",
+                    "raw.githubusercontent.com",
                     "1.1.1.1"
                 ],
                 "server": "dns-local"


### PR DESCRIPTION
Correctly bypass geoip and geosite download url.

The default bypass list only includes `githubusercontent.com` but it should also contain `raw.githubusercontent.com`. Note that this problem only manifests in clients which have just recently installed singbox. For those who already had singbox with a working hiddify installation, they already have the cache files and the file updates flawlessly. As such, this error only happens for new users and have escaped internal testing.