### PR TITLE
Fix 2nd link to mac os download

### DIFF
--- a/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
+++ b/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
@@ -346,21 +346,9 @@ class AppAPI(MethodView):
 
         if self.platform == Platform.all:
             platform = [Platform.windows, Platform.linux, Platform.mac]
-
-        if isinstance(platform, list):
-            for p in platform:
-                match p:
-                    case Platform.windows:
-                        ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64_en-US.msi'
-                        dto.install.append(self.__get_app_install_dto(AppInstallType.setup, ins_url))
-                    case Platform.linux:
-                        ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/hiddify-clash-desktop_{version}_amd64.AppImage'
-                        dto.install.append(self.__get_app_install_dto(AppInstallType.appimage, ins_url))
-                    case Platform.mac:
-                        ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64.dmg'
-                        dto.install.append(self.__get_app_install_dto(AppInstallType.dmg, ins_url))
-        else:
-            match platform:
+        
+        def get_link(p):
+            match p:
                 case Platform.windows:
                     ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64_en-US.msi'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.setup, ins_url))
@@ -368,8 +356,14 @@ class AppAPI(MethodView):
                     ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/hiddify-clash-desktop_{version}_amd64.AppImage'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.appimage, ins_url))
                 case Platform.mac:
-                    ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}x64.dmg'
+                    ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64.dmg'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.dmg, ins_url))
+
+        if isinstance(platform, list):
+            for p in platform:
+                get_link(p)
+        else:
+            get_link(platform)
 
         return dto
 

--- a/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
+++ b/hiddifypanel/panel/commercial/restapi/v2/user/apps_api.py
@@ -350,13 +350,13 @@ class AppAPI(MethodView):
         def get_link(p):
             match p:
                 case Platform.windows:
-                    ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64_en-US.msi'
+                    ins_url = latest_url.split('releases/')[0] + f'releases/download/v{version}/HiddifyClashDesktop_{version}_x64_en-US.msi'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.setup, ins_url))
                 case Platform.linux:
-                    ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/hiddify-clash-desktop_{version}_amd64.AppImage'
+                    ins_url = latest_url.split('releases/')[0] + f'releases/download/v{version}/hiddify-clash-desktop_{version}_amd64.AppImage'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.appimage, ins_url))
                 case Platform.mac:
-                    ins_url = latest_url.split('releases/')[0] + f'releases/download/{version}/HiddifyClashDesktop_{version}_x64.dmg'
+                    ins_url = latest_url.split('releases/')[0] + f'releases/download/v{version}/HiddifyClashDesktop_{version}_x64.dmg'
                     dto.install.append(self.__get_app_install_dto(AppInstallType.dmg, ins_url))
 
         if isinstance(platform, list):


### PR DESCRIPTION
Really fixes hiddify/hiddify-manager#3820 - also makes the code DRY so as to improve maintainability

My previous PR #173 only fixed the link in 1 place - I missed the 2nd link.

I've fixed this here and made the code more DRY (don't repeat yourself) so as to improve maintainability in the future.